### PR TITLE
Backend gathers customer and meter reading and payments during site pull

### DIFF
--- a/airtable/utils.js
+++ b/airtable/utils.js
@@ -1,0 +1,19 @@
+
+// Function receives a list of customers, meterReadings, and payments,
+// and adds the appropriate meter readings and payments to each customer object
+export const matchCustomersWithReadingsAndPayments = (customers, meterReadings, payments) => {
+    customers.forEach(customer => {
+        const customerId = customer.id;
+        customer.meterReadings = [];
+        customer.payments = [];
+
+        const customerMeterReadings =
+            meterReadings.filter(meterReading => meterReading.customerId === customerId);
+
+        const customerPayments =
+            payments.filter(payment => payment.customerId === customerId);
+
+        customer.meterReadings = customerMeterReadings;
+        customer.payments = customerPayments;
+    })
+}

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -1,6 +1,40 @@
+const { getCustomersByIds, getMeterReadingsandInvoicesByIds, getPaymentsByIds } = require("../airtable/request");
+const { matchCustomersWithReadingsAndPayments } = require("../airtable/utils");
 
 module.exports = {
-    Sites: (siteRecord, authRecord) => {
-        return siteRecord.fields.Users && siteRecord.fields.Users.includes(authRecord.id)
+    Sites: async (siteRecord, authRecord) => {
+        if (!siteRecord.fields.Users || !siteRecord.fields.Users.includes(authRecord.id)) {
+            return false;
+        }
+
+        // We resolve each site's customerId to their appropriate customer
+        const customerIds = siteRecord.fields.Customers;
+        if (customerIds) {
+            const customers = await getCustomersByIds(customerIds);
+            const meterReadingIds = [];
+            const paymentIds = [];
+
+            // We get all the meter reading and payment ids for all customers
+            // to minimize Airtable API calls, and then match the meter readings
+            // and payments received to their appropriate customer afterwards
+            customers.forEach(customer => {
+                const customerMeterReadingIds = customer.meterReadingIds;
+                const customerPaymentIds = customer.paymentIds;
+
+                if (customerMeterReadingIds) {
+                    meterReadingIds.push(...customerMeterReadingIds);
+                }
+
+                if (customerPaymentIds) {
+                    paymentIds.push(...customerPaymentIds);
+                }
+            })
+            const meterReadings = await getMeterReadingsandInvoicesByIds(meterReadingIds);
+            const payments = await getPaymentsByIds(paymentIds);
+            matchCustomersWithReadingsAndPayments(customers, meterReadings, payments);
+            siteRecord.fields.Customers = customers;
+        }
+
+        return siteRecord;
     }
 }


### PR DESCRIPTION
**Changelist**:
- Additionally pull `customers` and their `payments` and `meter readings` when pulling a `site`.
- Associated frontend PR: https://github.com/calblueprint/meepanyar/pull/27 

The above was previously done on the frontend. It was moved to the backend for speed/reliability. The method used minimizes the number of API calls necessary compared to the method used on the frontend.