### PR TITLE
Add customer tariff plan to site pull

### DIFF
--- a/airtable/utils.js
+++ b/airtable/utils.js
@@ -1,19 +1,30 @@
-
 // Function receives a list of customers, meterReadings, and payments,
-// and adds the appropriate meter readings and payments to each customer object
-export const matchCustomersWithReadingsAndPayments = (customers, meterReadings, payments) => {
-    customers.forEach(customer => {
-        const customerId = customer.id;
-        customer.meterReadings = [];
-        customer.payments = [];
+// and adds the appropriate meter readings, payments, and tariff info to each customer object
+export const matchCustomersWithReadingsPaymentsAndTariff = (
+  customers,
+  meterReadings,
+  payments,
+  tariffPlans
+) => {
+  customers.forEach((customer) => {
+    const customerId = customer.id;
+    customer.meterReadings = [];
+    customer.payments = [];
 
-        const customerMeterReadings =
-            meterReadings.filter(meterReading => meterReading.customerId === customerId);
+    const customerMeterReadings = meterReadings.filter(
+      (meterReading) => meterReading.customerId === customerId
+    );
 
-        const customerPayments =
-            payments.filter(payment => payment.customerId === customerId);
+    const customerPayments = payments.filter(
+      (payment) => payment.customerId === customerId
+    );
 
-        customer.meterReadings = customerMeterReadings;
-        customer.payments = customerPayments;
-    })
-}
+    const customerTariff = tariffPlans.filter((tariff) =>
+      tariff.customerIds.includes(customerId)
+    );
+
+    [customer.tariffPlans] = customerTariff;
+    customer.meterReadings = customerMeterReadings;
+    customer.payments = customerPayments;
+  });
+};

--- a/airtable/utils.js
+++ b/airtable/utils.js
@@ -1,6 +1,6 @@
 // Function receives a list of customers, meterReadings, and payments,
 // and adds the appropriate meter readings, payments, and tariff info to each customer object
-export const matchCustomersWithReadingsPaymentsAndTariff = (
+export const matchCustomers = (
   customers,
   meterReadings,
   payments,

--- a/airtable/utils.js
+++ b/airtable/utils.js
@@ -1,11 +1,6 @@
 // Function receives a list of customers, meterReadings, and payments,
-// and adds the appropriate meter readings, payments, and tariff info to each customer object
-export const matchCustomers = (
-  customers,
-  meterReadings,
-  payments,
-  tariffPlans
-) => {
+// and adds the appropriate meter readings and payments to each customer object
+export const matchCustomers = (customers, meterReadings, payments) => {
   customers.forEach((customer) => {
     const customerId = customer.id;
     customer.meterReadings = [];
@@ -19,11 +14,6 @@ export const matchCustomers = (
       (payment) => payment.customerId === customerId
     );
 
-    const customerTariff = tariffPlans.filter((tariff) =>
-      tariff.customerIds.includes(customerId)
-    );
-
-    [customer.tariffPlans] = customerTariff;
     customer.meterReadings = customerMeterReadings;
     customer.payments = customerPayments;
   });

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -30,7 +30,6 @@ module.exports = {
       customers.forEach((customer) => {
         const customerMeterReadingIds = customer.meterReadingIds;
         const customerPaymentIds = customer.paymentIds;
-        const customerTariffPlansIds = customer.tariffPlansId;
 
         if (customerMeterReadingIds) {
           meterReadingIds.push(...customerMeterReadingIds);
@@ -39,24 +38,19 @@ module.exports = {
         if (customerPaymentIds) {
           paymentIds.push(...customerPaymentIds);
         }
-
-        if (customerTariffPlansIds) {
-          tariffPlanIds.push(customerTariffPlansIds);
-        }
       });
 
-      let [meterReadings, payments, tariffPlans] = await Promise.all([
+      let [meterReadings, payments] = await Promise.all([
         getMeterReadingsandInvoicesByIds(meterReadingIds),
         getPaymentsByIds(paymentIds),
-        getTariffPlansByIds(tariffPlanIds),
       ]);
 
-      matchCustomers(customers, meterReadings, payments, tariffPlans);
+      matchCustomers(customers, meterReadings, payments);
 
       siteRecord.fields.Customers = customers;
     }
 
-    const financialSummaryIds = siteRecord.fields["Financial Summaries"];
+    const financialSummaryIds = siteRecord.fields["Fainancial Summaries"];
     let financialSummaries = [];
     if (financialSummaryIds) {
       financialSummaries = await getFinancialSummariesByIds(
@@ -64,6 +58,14 @@ module.exports = {
       );
     }
     siteRecord.fields.FinancialSummaries = financialSummaries;
+
+    const tariffPlanIds = siteRecord.fields["Tariff Plans"];
+    let tariffPlans = [];
+    if (tariffPlanIds) {
+      tariffPlans = await getTariffPlansByIds(tariffPlanIds);
+    }
+    siteRecord.fields.TariffPlans = tariffPlans;
+
     return siteRecord;
   },
 };

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -2,13 +2,9 @@ const {
   getCustomersByIds,
   getMeterReadingsandInvoicesByIds,
   getPaymentsByIds,
-  getTariffPlanById,
   getTariffPlansByIds,
 } = require("../airtable/request");
-const {
-  matchCustomersWithReadingsAndPayments,
-  matchCustomersWithReadingsPaymentsAndTariff,
-} = require("../airtable/utils");
+const { matchCustomers } = require("../airtable/utils");
 
 module.exports = {
   Sites: async (siteRecord, authRecord) => {
@@ -54,12 +50,7 @@ module.exports = {
         getTariffPlansByIds(tariffPlanIds),
       ]);
 
-      matchCustomersWithReadingsPaymentsAndTariff(
-        customers,
-        meterReadings,
-        payments,
-        tariffPlans
-      );
+      matchCustomers(customers, meterReadings, payments, tariffPlans);
 
       siteRecord.fields.Customers = customers;
     }

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -1,40 +1,69 @@
-const { getCustomersByIds, getMeterReadingsandInvoicesByIds, getPaymentsByIds } = require("../airtable/request");
-const { matchCustomersWithReadingsAndPayments } = require("../airtable/utils");
+const {
+  getCustomersByIds,
+  getMeterReadingsandInvoicesByIds,
+  getPaymentsByIds,
+  getTariffPlanById,
+  getTariffPlansByIds,
+} = require("../airtable/request");
+const {
+  matchCustomersWithReadingsAndPayments,
+  matchCustomersWithReadingsPaymentsAndTariff,
+} = require("../airtable/utils");
 
 module.exports = {
-    Sites: async (siteRecord, authRecord) => {
-        if (!siteRecord.fields.Users || !siteRecord.fields.Users.includes(authRecord.id)) {
-            return false;
-        }
-
-        // We resolve each site's customerId to their appropriate customer
-        const customerIds = siteRecord.fields.Customers;
-        if (customerIds) {
-            const customers = await getCustomersByIds(customerIds);
-            const meterReadingIds = [];
-            const paymentIds = [];
-
-            // We get all the meter reading and payment ids for all customers
-            // to minimize Airtable API calls, and then match the meter readings
-            // and payments received to their appropriate customer afterwards
-            customers.forEach(customer => {
-                const customerMeterReadingIds = customer.meterReadingIds;
-                const customerPaymentIds = customer.paymentIds;
-
-                if (customerMeterReadingIds) {
-                    meterReadingIds.push(...customerMeterReadingIds);
-                }
-
-                if (customerPaymentIds) {
-                    paymentIds.push(...customerPaymentIds);
-                }
-            })
-            const meterReadings = await getMeterReadingsandInvoicesByIds(meterReadingIds);
-            const payments = await getPaymentsByIds(paymentIds);
-            matchCustomersWithReadingsAndPayments(customers, meterReadings, payments);
-            siteRecord.fields.Customers = customers;
-        }
-
-        return siteRecord;
+  Sites: async (siteRecord, authRecord) => {
+    if (
+      !siteRecord.fields.Users ||
+      !siteRecord.fields.Users.includes(authRecord.id)
+    ) {
+      return false;
     }
-}
+
+    // We resolve each site's customerId to their appropriate customer
+    const customerIds = siteRecord.fields.Customers;
+    if (customerIds) {
+      const customers = await getCustomersByIds(customerIds);
+      const meterReadingIds = [];
+      const paymentIds = [];
+      const tariffPlanIds = [];
+
+      // We get all the meter reading and payment ids for all customers
+      // to minimize Airtable API calls, and then match the meter readings
+      // and payments received to their appropriate customer afterwards
+      customers.forEach((customer) => {
+        const customerMeterReadingIds = customer.meterReadingIds;
+        const customerPaymentIds = customer.paymentIds;
+        const customerTariffPlansIds = customer.tariffPlansId;
+
+        if (customerMeterReadingIds) {
+          meterReadingIds.push(...customerMeterReadingIds);
+        }
+
+        if (customerPaymentIds) {
+          paymentIds.push(...customerPaymentIds);
+        }
+
+        if (customerTariffPlansIds) {
+          tariffPlanIds.push(customerTariffPlansIds);
+        }
+      });
+
+      let [meterReadings, payments, tariffPlans] = await Promise.all([
+        getMeterReadingsandInvoicesByIds(meterReadingIds),
+        getPaymentsByIds(paymentIds),
+        getTariffPlansByIds(tariffPlanIds),
+      ]);
+
+      matchCustomersWithReadingsPaymentsAndTariff(
+        customers,
+        meterReadings,
+        payments,
+        tariffPlans
+      );
+
+      siteRecord.fields.Customers = customers;
+    }
+
+    return siteRecord;
+  },
+};


### PR DESCRIPTION
**UPDATE: March 2, 2021** (ended up reversing a lot of my original changes)
- Test with the corresponding front-end here: https://github.com/calblueprint/meepanyar/pull/39
- Changed from attaching tariffs to individual customer records to pulling all tariff plans for the site and looking up by the customer's `tariffPlansId`

Next steps:
- Update naming/plurality of Tariff Plans in Airtable + update schema _please_


**Feb 21, 2021**
- Follow-up on #3 to pull customer tariff info in addition to payment + meter readings. 
- Small optimization: instead of await-ing all the `getMeterReadingsandInvoicesByIds`, `getPaymentsByIds`, and `getTariffPlansByIds` sequentially, `Promise.all` should now wait for all fulfillments.

Note: for some reason my prettier settings were really unhappy :^)