### PR TITLE
[Translation Support] Create resources object from Airtable translations DB

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -1,0 +1,50 @@
+const Airtable = require('airtable');
+const dotenv = require("dotenv");
+dotenv.config();
+
+const BASE_ID = process.env.TRANSLATIONS_BASE_ID;
+const API_KEY = process.env.TRANSLATIONS_API_KEY;
+const ENDPOINT_URL = 'https://api.airtable.com';
+const VIEW = 'Grid view';
+
+Airtable.configure({
+    endpointUrl: ENDPOINT_URL,
+    apiKey: API_KEY,
+});
+  
+const base = Airtable.base(BASE_ID);
+
+const getAllRecords = (table, filterByFormula = '', sort = []) => {
+    return base(table)
+      .select({
+        view: VIEW,
+        filterByFormula,
+        sort,
+      })
+      .all()
+      .then((records) => {
+        if (records === null || records.length < 1) {
+          return [];
+        }
+        const translations = {}; 
+        for (const record of records) {
+            translations[record.get('EN')] = record.get('MM')
+        }
+        return translations; 
+      })
+      .catch((err) => {
+        throw err;
+      });
+}
+
+const getAndSetTranslations = async () => {
+    try {
+        const resultData = await getAllRecords('Translation'); 
+        const resources = { bur: { translation: resultData } }; 
+        console.log(resources); 
+    } catch (err) {
+        console.log('Error when creating translations: ', err);
+    }
+}
+
+getAndSetTranslations(); 


### PR DESCRIPTION
# In this PR 
I'm using `meepanyar-node` to experiment with the Translations Airtable. This branch includes a script that pulls down translations from the Airtable and formats it according to [react-i18next](https://react.i18next.com/guides/quick-start) conventions. This pull request does not need to be merged into main. 

This pull request is part of the [Translation Support Feature](https://www.notion.so/calblueprint/Translation-Support-Design-Document-7703018a8c4e403dab8aaa49d2a322e7#222323ac6b0b4ada80b8c801898abf1d)

## Usage 
Upon running `node translations.js`, the output appears to look like the following: 
```
{
  bur: {
    translation: {
      'Cancel': 'ဖျက်သိမ်းမည်',
      'Close': 'ပိတ်မည်',
      'Incident Date (Date of Occurence)': 'ဖြစ်ရပ်သည့်နေ့',
      'Preventative Maintenance': 'ကြိုတင်ထိန်းသိမ်းမှု',
      'Remaining': 'ပမာဏ',
      'Spent [Money]': 'သုံးစွဲငွေ',
      'Submit': 'တင်သွင်းမည်',
      ... <a lot more rows> 
  }
}
```
