### PR TITLE
Changed Customer property to CustomerData

### DIFF
--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -76,7 +76,7 @@ module.exports = {
     await Promise.all(promises);
 
     matchCustomers(customers, meterReadings, payments);
-    siteRecord.fields.Customers = customers;
+    siteRecord.fields.CustomerData = customers;
     siteRecord.fields.FinancialSummaries = financialSummaries;
     siteRecord.fields.TariffPlans = tariffPlans;
 


### PR DESCRIPTION
Customer property was overloaded because it was used for `CustomerId` and the property used to send customer objects. Now the property used to send customer objects will be called `CustomerData`