### PR TITLE
Image upload functionality for purchase requests

### DIFF
--- a/lib/photoUtils.js
+++ b/lib/photoUtils.js
@@ -32,3 +32,11 @@ export async function deleteBlob(blobName) {
     const blockBlobClient = containerClient.getBlockBlobClient(blobName);
     blockBlobClient.deleteIfExists().then(console.log);
 }
+
+// Generate a filename with the format YYYY-MM-RANDOM#
+export function generateFileName() {
+    const year = new Date().getFullYear();
+    const month = new Date().getMonth();
+    const randomNumber = Math.random();
+    return `${year}-${month}-${randomNumber}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,9 +1335,9 @@
       "dev": true
     },
     "airlock-server": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/airlock-server/-/airlock-server-0.3.2.tgz",
-      "integrity": "sha512-bnzdgi8/PSCFB+7UX3YN9pkaQrPLlHK//YoxkfpojBInNAzoM0LTSdqfeytAjv6NWJe10bR6ZaNBP6bUe68/dQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/airlock-server/-/airlock-server-0.3.3.tgz",
+      "integrity": "sha512-78BmA6B1HsktPmVV00pCVvZk3PY4d7nJreER2oweodqfCoSJ24awOeaYXaknqfF1+KSGD8LwZr3YDwoZsPdFDQ==",
       "requires": {
         "@types/airtable": "^0.5.7",
         "@types/bcrypt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/core": "^7.12.3",
     "@babel/node": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "airlock-server": "^0.3.2",
+    "airlock-server": "^0.3.3",
     "airtable": "^0.10.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -11,7 +11,7 @@ const {
 } = require("../airtable/request");
 const { matchCustomers } = require("../airtable/utils");
 import { Tables } from "../airtable/schema";
-import { uploadBlob } from "../lib/photoUtils";
+import { generateFileName, uploadBlob } from "../lib/photoUtils";
 
 module.exports = {
   [Tables.Sites]: async (siteRecord, authRecord) => {
@@ -144,11 +144,7 @@ module.exports = {
       if (purchaseRequestRecord.fields.hasOwnProperty("Receipt")) {
         const dataURI = purchaseRequestRecord.fields.Receipt[0].url;
         try {
-          const year = new Date().getFullYear();
-          const month = new Date().getMonth();
-          const randomNumber = Math.random();
-          const blobName = `${year}-${month}-${randomNumber}`;
-          const photoUrl = await uploadBlob(blobName, dataURI);
+          const photoUrl = await uploadBlob(generateFileName(), dataURI);
           purchaseRequestRecord.fields.Receipt = [{ url: photoUrl }];
         } catch (error) {
           console.log("Error in PurchaseRequests write resolver: ", error);

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -137,4 +137,21 @@ module.exports = {
     siteRecord.fields.InventoryUpdates = inventoryUpdates;
     return siteRecord;
   },
+  PurchaseRequests: async (purchaseRequestRecord, authRecord) => {
+    console.log("hello");
+  },
+  // PurchaseRequests: {
+  //   write: async (purchaseRequestRecord, authRecord) => {
+  //     console.log( "access resolver purchaserequests!", purchaseRequestRecord);
+  //     const dataURI = purchaseRequestRecord.receipt[0].url;
+
+  //     const year = new Date().getFullYear();
+  //     const month = new Date().getMonth();
+  //     const randomNumber = Math.random();
+  //     const blobName = `${year}-${month}-${randomNumber}`;
+  //     const photoUrl = await uploadBlob(blobName, dataURI);
+  //     console.log("heres the photo url", photoUrl);
+  //     purchaseRequestRecord.receipt = photoUrl;
+  //   },
+  // },
 };

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -151,11 +151,8 @@ module.exports = {
           const photoUrl = await uploadBlob(blobName, dataURI);
           purchaseRequestRecord.fields.Receipt = [{ url: photoUrl }];
         } catch (error) {
-          console.log("error in write", error);
+          console.log("Error in PurchaseRequests write resolver: ", error);
         }
-        console.log("final pr record", purchaseRequestRecord);
-      } else {
-        console.log("skipping image stuff");
       }
       return purchaseRequestRecord;
     },


### PR DESCRIPTION
Added a write resolver to upload receipt images for purchase requests.

Companion front-end PR: https://github.com/calblueprint/meepanyar/pull/69

**Note on large file sizes:**
![image](https://user-images.githubusercontent.com/21160510/113604649-6abbfe80-95fa-11eb-9d6b-d70e2121d394.png)
We encountered this issue when uploading larger images (though not reproducible by regular webcams). I tried fixes detailed in these posts with no success. 
- https://stackoverflow.com/questions/19917401/error-request-entity-too-large/19965089#19965089
- https://stackoverflow.com/questions/50304779/payloadtoolargeerror-request-entity-too-large

We decided to table it since this is likely an obscure edge case caused by the [mmhmm camera app ](https://www.mmhmm.app/)
