### PR TITLE
[Schema Change] Renamed Min Units column to Free Units in Tariff Plan

### DIFF
--- a/airtable/schema.js
+++ b/airtable/schema.js
@@ -71,6 +71,7 @@ export const Columns = {
 		id: {name:`ID`, type:`formula`},
 		meterType: {name:`Meter Type`, type:`select`},
 		customerNumber: {name:`Customer Number`, type:`number`},
+		startingMeterReading: {name:`Starting Meter Reading`, type:`number`},
 	},
 	"Customer Updates": {
 		dateUpdated: {name:`Date Updated`, type:`date`},

--- a/airtable/schema.js
+++ b/airtable/schema.js
@@ -50,7 +50,7 @@ export const Columns = {
 		name: {name:`Name`, type:`text`},
 		fixedTariff: {name:`Fixed Tariff`, type:`number`},
 		tariffByUnit: {name:`Tariff By Unit`, type:`number`},
-		minUnits: {name:`Min Units`, type:`number`},
+		freeUnits: {name:`Free Units`, type:`number`},
 		customerIds: {name:`Customer`, type:`foreignKey-many`},
 		siteIds: {name:`Sites`, type:`foreignKey-many`},
 		id: {name:`ID`, type:`formula`},


### PR DESCRIPTION
Tariff Plan's "Min Units" column was renamed to "Free Units". This PR runs the schema generator. Also adding a column "Starting Meter Reading" to customer column to keep track of meter reading to start from for customers

I temporarily changed the "Free Units" column back to "Min Units" to not block anyone else. When merging this PR, "Min Units" column should be changed back to "Free Units"