### PR TITLE
Schema change and send inactive to frontend

### DIFF
--- a/airtable/schema.js
+++ b/airtable/schema.js
@@ -55,8 +55,8 @@ export const Columns = {
 		customerIds: {name:`Customer`, type:`foreignKey-many`},
 		siteIds: {name:`Sites`, type:`foreignKey-many`},
 		id: {name:`ID`, type:`formula`},
-		numberOfCustomers: {name:`Number of Customers`, type:`count`},
 		meterTypes: {name:`Meter Types`, type:`multiSelect`},
+		numberOfCustomers: {name:`Number of Customers`, type:`count`},
 	},
 	"Customers": {
 		name: {name:`Name`, type:`text`},
@@ -154,6 +154,7 @@ export const Columns = {
 		siteName: {name:`Site Name`, type:`lookup`},
 		amountSpent: {name:`Amount Spent`, type:`number`},
 		id: {name:`ID`, type:`formula`},
+		updatedQuantity: {name:`Updated Quantity`, type:`number`},
 	},
 	"Inventory Updates": {
 		primaryKey: {name:`Primary Key`, type:`formula`},

--- a/airtable/schema.js
+++ b/airtable/schema.js
@@ -35,6 +35,7 @@ export const Columns = {
 		inventoryUpdateIds: {name:`Inventory Updates`, type:`foreignKey-many`},
 		organization: {name:`Organization`, type:`text`},
 		admin: {name:`Admin`, type:`checkbox`},
+		inactive: {name:`Inactive`, type:`checkbox`},
 	},
 	"Sites": {
 		name: {name:`Name`, type:`text`},
@@ -54,6 +55,8 @@ export const Columns = {
 		customerIds: {name:`Customer`, type:`foreignKey-many`},
 		siteIds: {name:`Sites`, type:`foreignKey-many`},
 		id: {name:`ID`, type:`formula`},
+		numberOfCustomers: {name:`Number of Customers`, type:`count`},
+		meterTypes: {name:`Meter Types`, type:`multiSelect`},
 	},
 	"Customers": {
 		name: {name:`Name`, type:`text`},
@@ -72,6 +75,7 @@ export const Columns = {
 		meterType: {name:`Meter Type`, type:`select`},
 		customerNumber: {name:`Customer Number`, type:`number`},
 		startingMeterReading: {name:`Starting Meter Reading`, type:`number`},
+		startingMeterLastChanged: {name:`Starting Meter Last Changed`, type:`date`},
 	},
 	"Customer Updates": {
 		dateUpdated: {name:`Date Updated`, type:`date`},

--- a/resolvers/index.js
+++ b/resolvers/index.js
@@ -95,10 +95,11 @@ module.exports = {
     const siteUsersPromise = getAllUsers().then((result) =>
       result
         .filter((user) => user.siteIds?.includes(siteRecord.id))
-        .map(({ id, admin, username, name, siteIds }) =>
+        .map(({ id, admin, username, name, siteIds, inactive }) =>
           siteUsers.push({
             id,
             admin: admin || false,
+            inactive: inactive || false,
             username,
             name,
             siteIds,


### PR DESCRIPTION
Column in Tariff Plan to keep track of number of customers attached to tariff plan
Column in Tariff Plan to keep track of what kinds of meter readings this tariff plan can apply for
Adding a column to Customers to keep track of the last time its starting meter was changed
Active status for users
Updated Quantity number column for Purchase Requests