### PR TITLE
[Inventory] Fix offline functionality for new products and inventory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import Airlock from 'airlock-server';
-import express from 'express';
-import moment from 'moment';
+import Airlock from "airlock-server";
+import express from "express";
+import moment from "moment";
 import {
   createCustomer,
   createFinancialSummarie,
@@ -16,15 +16,17 @@ import {
   getFinancialSummariesByIds,
   getPurchaseRequestsByIds,
   getSiteById,
-  updateFinancialSummarie
+  updateFinancialSummarie,
 } from "./airtable/request";
 import {
   calculateNumCustomersBilled,
-  calculateNumCustomersPaid, calculateTotalActiveCustomers,
+  calculateNumCustomersPaid,
+  calculateTotalActiveCustomers,
   calculateTotalAmountBilled,
   calculateTotalAmountCollected,
-  calculateTotalAmountSpent, calculateTotalUsage
-} from './lib/financialSummaryUtils';
+  calculateTotalAmountSpent,
+  calculateTotalUsage,
+} from "./lib/financialSummaryUtils";
 
 
 const airlockPort = process.env.PORT || 4000;

--- a/index.js
+++ b/index.js
@@ -119,6 +119,8 @@ app.post('/customers/create', async (request, result) => {
 
 // Endpoint to create a new inventory item and an initial inventory update.
 // Assumes that the site, user, and product already exist in Airtable.
+// This custom endpoint is needed to account for offline functionality which 
+// requires that both items are created in a single endpoint.
 app.post("/inventory/create", async (request, result) => {
   try {
     const requestData = request.body;
@@ -155,6 +157,8 @@ app.post("/inventory/create", async (request, result) => {
 // Endpoint to create a new product, as well as a corresponding
 // inventory and inventory update record.
 // Assumes that the site and user exist in Airtable.
+// This custom endpoint is needed to account for offline functionality which 
+// requires that all three items are created in a single endpoint.
 app.post("/products/create", async (request, result) => {
   try {
     const {startingAmount, siteId, userId, ...product} = request.body;

--- a/index.js
+++ b/index.js
@@ -5,8 +5,10 @@ import {
   createCustomer,
   createFinancialSummarie,
   createInventory,
+  createInventoryUpdate,
   createManyMeterReadingsandInvoices,
   createManyPayments,
+  createProduct,
   getAllInventorys,
   getAllMeterReadingsandInvoices,
   getAllPayments,
@@ -16,16 +18,14 @@ import {
   getSiteById,
   updateFinancialSummarie
 } from "./airtable/request";
-
 import {
-  calculateTotalActiveCustomers,
   calculateNumCustomersBilled,
-  calculateNumCustomersPaid,
+  calculateNumCustomersPaid, calculateTotalActiveCustomers,
   calculateTotalAmountBilled,
-  calculateTotalUsage,
   calculateTotalAmountCollected,
-  calculateTotalAmountSpent
+  calculateTotalAmountSpent, calculateTotalUsage
 } from './lib/financialSummaryUtils';
+
 
 const airlockPort = process.env.PORT || 4000;
 const apiKey = process.env.AIRTABLE_API_KEY;
@@ -115,23 +115,81 @@ app.post('/customers/create', async (request, result) => {
   }
 })
 
-// Endpoint used to create a new inventory item.
-// Contains a site id (the site already exists in airtable).
+// Endpoint to create a new inventory item and an initial inventory update.
+// Assumes that the site, user, and product already exist in Airtable.
 app.post("/inventory/create", async (request, result) => {
   try {
-    const inventoryData = request.body;
-    // Remove the blank id field
-    delete inventoryData.id;
-    console.log("Inventory data: ", inventoryData);
+    const requestData = request.body;
+    const {userId, ...inventory} = requestData;
+    delete inventory.id; // Remove the blank id field
+    console.log("Inventory data: ", inventory);
 
-    const inventoryId = await createInventory(inventoryData);
+    const inventoryId = await createInventory(inventory);
     console.log("Inventory id:", inventoryId);
-    console.log("Inventory created!");
+    console.log("Inventory created!\n\n");
+
+    const inventoryUpdate = {
+      userId: userId,
+      previousQuantity: 0,
+      updatedQuantity: inventory.currentQuantity,
+      inventoryId: inventoryId,
+      createdAt: moment().toISOString(),
+    }
+
+    console.log("Inventory Update data: ", inventory);
+    const inventoryUpdateId = await createInventoryUpdate(inventoryUpdate);
+    console.log("Inventory Update id:", inventoryUpdateId);
+    console.log("Inventory Update created!\n\n");
 
     result.status(201);
-    result.json({ status: "OK", id: inventoryId });
+    result.json({ status: "OK", inventoryId, inventoryUpdateId });
   } catch (err) {
-    console.log("Error when creating inventory: ", err);
+    console.log("Error when creating inventory and/or update: ", err);
+    result.status(400);
+    result.json({ error: err });
+  }
+});
+
+// Endpoint to create a new product, as well as a corresponding
+// inventory and inventory update record.
+// Assumes that the site and user exist in Airtable.
+app.post("/products/create", async (request, result) => {
+  try {
+    const {startingAmount, siteId, userId, ...product} = request.body;
+
+    delete product.id; // Remove the blank id field
+    console.log("Product data: ", product);
+    const productId = await createProduct(product);
+    console.log("Product id:", productId);
+    console.log("Product created!\n\n");
+
+    const inventory = {
+      productId,
+      siteId,
+      currentQuantity: startingAmount,
+      periodStartQuantity: startingAmount,
+    }
+    console.log("Inventory data: ", inventory);
+    const inventoryId = await createInventory(inventory);
+    console.log("Inventory id:", inventoryId);
+    console.log("Inventory created! \n\n");
+
+    const inventoryUpdate = {
+      userId: userId,
+      previousQuantity: 0,
+      updatedQuantity: startingAmount,
+      inventoryId: inventoryId,
+      createdAt: moment().toISOString(),
+    }
+    console.log("Inventory Update data: ", inventoryUpdate);
+    const inventoryUpdateId = await createInventoryUpdate(inventoryUpdate);
+    console.log("Inventory Update id:", inventoryUpdateId);
+    console.log("Inventory Update created! \n\n");
+
+    result.status(201);
+    result.json({ status: "OK", productId, inventoryId, inventoryUpdateId });
+  } catch (err) {
+    console.log("Error when creating product, inventory, and/or inventory update: ", err);
     result.status(400);
     result.json({ error: err });
   }


### PR DESCRIPTION
This PR corresponds to the changes in https://github.com/calblueprint/meepanyar/pull/131
- Updates the `/inventory/create` endpoint to also create an inventory update and return the new ids
- Introduces a `/products/create` endpoint which creates a product, inventory record, and inventory update.

These changes are necessary to support offline inventory and product creation. This resolves an issue where new product or inventory records that were created offline (with generated integer IDs, not Airtable IDs) needed to be linked to other new connected records (e.g inventory for a new product, inventory update for a new inventory) but the ids were invalid since they weren't Airtable IDs yet. This way, all of that logic is combined in these endpoints and mocked on the front end until the network is restored and the requests are resolved.