### PR TITLE
Script and endpoint to charge No Meter customers

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ app.post("/meter-readings-invoice/create", async (request, result) => {
       customerId: customer.id,
       amountBilled: tariffPlan.fixedTariff,
       date: moment().toISOString(),
+      reading: 0,
     }
   
     console.log("Creating invoice:", invoice);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "generate-schema": "generate-airtable-schema",
     "start": "babel-node index.js",
     "update-summaries": "babel-node -r dotenv/config scripts/updateFinancialSummaryData.js",
+    "charge-no-meter-customers": "babel-node -r dotenv/config scripts/chargeNoMeterCustomers.js",
     "generate-keys": "cd config && openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -outform PEM -pubout -out jwt.key.pub",
     "heroku-postbuild": "npm run generate-keys"
   },

--- a/scripts/chargeNoMeterCustomers.js
+++ b/scripts/chargeNoMeterCustomers.js
@@ -1,0 +1,41 @@
+const fetch = require("node-fetch");
+const { getAllCustomers } = require("../airtable/request");
+
+require("dotenv").config();
+
+const SERVER_URL = process.env.SERVER_URL;
+
+// This script is to be run once a month by Heroku Scheduler
+// It creates a MeterReadingAndInvoice record for the customer and charges the Fixed Tariff value
+// from their tariff plan.
+// Modify the frequency of how often this script is run via the Heroku Scheduler Portal.
+const chargeNoMeter = async () => {
+  const customers = await getAllCustomers();
+  const noMeterCustomers = customers.filter(
+    (customer) => customer.meterType === "No Meter"
+  );
+
+  noMeterCustomers.forEach(async (customer) => {
+    await chargeNoMeterCustomers(customer.id);
+  });
+};
+
+const chargeNoMeterCustomers = async (customerId) => {
+  const url = `${SERVER_URL}/meter-readings-invoice/create`;
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ customerId }),
+    });
+    console.log(
+      `Invoice created for customer: ${customerId}, response: ${response.id}`
+    );
+  } catch (err) {
+    console.log("(chargeNoMeterCustomers) Error: ", err);
+  }
+};
+
+chargeNoMeter();

--- a/scripts/chargeNoMeterCustomers.js
+++ b/scripts/chargeNoMeterCustomers.js
@@ -10,14 +10,14 @@ const SERVER_URL = process.env.SERVER_URL;
 // from their tariff plan.
 // Modify the frequency of how often this script is run via the Heroku Scheduler Portal.
 const chargeNoMeter = async () => {
-  const customers = await getAllCustomers();
-  const noMeterCustomers = customers.filter(
-    (customer) => customer.meterType === "No Meter"
-  );
-
-  noMeterCustomers.forEach(async (customer) => {
-    await chargeNoMeterCustomers(customer.id);
-  });
+  try {
+    const noMeterCustomers = await getAllCustomers("{Meter Type} = 'No Meter'");
+    noMeterCustomers.forEach(async (customer) => {
+      await chargeNoMeterCustomers(customer.id);
+    });
+  } catch (err) {
+    console.log("(chargeNoMeter) Error:", err);
+  }
 };
 
 const chargeNoMeterCustomers = async (customerId) => {
@@ -31,7 +31,7 @@ const chargeNoMeterCustomers = async (customerId) => {
       body: JSON.stringify({ customerId }),
     });
     console.log(
-      `Invoice created for customer: ${customerId}, response: ${response.id}`
+      `Invoice created for customer: ${customerId}, response: ${response}`
     );
   } catch (err) {
     console.log("(chargeNoMeterCustomers) Error: ", err);


### PR DESCRIPTION
**This PR:**
1. Introduces an endpoint that creates a MeterReadingAndInvoice record a customer with Meter Type = "No Meter".
2. Introduces a script that calls this endpoint to update all financial summary sites. This script is going to be set to be called once per month via Heroku's chron scheduler.

**How to Review:**
1. Run an instance of meepanyar-node
2. In another terminal, run the script via `npm run charge-no-meter-customers`
3. Verify that new records are created in the **Meter Readings and Invoices** table for all customers with meter type No Meter.