### PR TITLE
Remove heroku postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "update-summaries": "babel-node -r dotenv/config scripts/updateFinancialSummaryData.js",
     "update-customer-starting-meters": "babel-node -r dotenv/config scripts/updateCustomerStartingMeters.js",
     "charge-no-meter-customers": "babel-node -r dotenv/config scripts/chargeNoMeterCustomers.js",
-    "generate-keys": "cd config && openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -outform PEM -pubout -out jwt.key.pub",
-    "heroku-postbuild": "npm run generate-keys"
+    "generate-keys": "cd config && openssl genrsa -out jwt.key 2048 && openssl rsa -in jwt.key -outform PEM -pubout -out jwt.key.pub"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR removes the key generation done when heroku builds the backend. Instead, PRIVATE_KEY and PUBLIC_KEY environment variables are used. This is so people don't have to login again after every backend deployment. More documentation details https://www.notion.so/calblueprint/Airlock-Server-1e2f28ad7b71409faa56f20aa0cba5f8 